### PR TITLE
Fixing std::expected implementation to have non-terrible codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ bin/%.o: %.cpp
 	$(CXX) -O3 -std=c++20 -c -W -Wall $(CXXFLAGS-$(basename $@)) -o$@ $<
 
 bin/runtests: bin/main.o bin/exceptions.o bin/leaf.o bin/expected.o bin/herbceptionemulation.o bin/herbceptions.o bin/outcome.o bin/baseline.o
-	$(CXX) -o$@ $^
+	$(CXX) -o$@ $^ -lpthread
 
 bin/benchmark/src/libbenchmark.a:
 	@mkdir -p bin/benchmark


### PR DESCRIPTION
In [P2544](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2544r0.html#expected) you state that expected has significant runtime overhead for fib:

> Single threaded the fib code using std::expected is more than four times slower than using traditional exceptions. 

That didn't seem quite right to me. I investigated the `std::expected` implementation used here, and it turns out that it suffers from a [gcc codegen issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95384) that I reported a couple years.

This PR fixes the implementation to avoid that issue. It's now, technically, no longer a conforming `expected` implementation, but not in a way that's relevant for the benchmark (it no longer properly constraints its special member functions), but it's more in line with what you'd expect with this approach to error handling. 

On my laptop, this changes the numbers I got for fib from

```
testing std::expected using 1 2 4 6 threads
failure rate 0%: 71 71 72 76
failure rate 0.1%: 71 71 71 73
failure rate 1%: 72 72 79 77
failure rate 10%: 70 71 78 80
```
to
```
testing std::expected using 1 2 4 6 threads
failure rate 0%: 32 34 34 52
failure rate 0.1%: 34 34 35 49
failure rate 1%: 31 35 45 45
failure rate 10%: 35 37 38 41
```
This is still slower than exceptions for this problem, but it's at least not _four times_ slower. 